### PR TITLE
Added support for mail order account type

### DIFF
--- a/src/SagePayMvc/ITransactionRegistrar.cs
+++ b/src/SagePayMvc/ITransactionRegistrar.cs
@@ -26,7 +26,7 @@ namespace SagePayMvc {
 		/// Sends a transaction registration to SagePay and receives a TransactionRegistrationResponse
 		/// </summary>
 		TransactionRegistrationResponse Send(RequestContext context, string vendorTxCode, ShoppingBasket basket,
-		                                     Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode = "GBP",
-                                             		MerchantAccountType accountType = MerchantAccountType.Ecommerce);
+															Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode = "GBP",
+															MerchantAccountType accountType = MerchantAccountType.Ecommerce);
 	}
 }

--- a/src/SagePayMvc/ITransactionRegistrar.cs
+++ b/src/SagePayMvc/ITransactionRegistrar.cs
@@ -26,6 +26,7 @@ namespace SagePayMvc {
 		/// Sends a transaction registration to SagePay and receives a TransactionRegistrationResponse
 		/// </summary>
 		TransactionRegistrationResponse Send(RequestContext context, string vendorTxCode, ShoppingBasket basket,
-		                                     Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode = "GBP");
+		                                     Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode = "GBP",
+                                             		MerchantAccountType accountType = MerchantAccountType.Ecommerce);
 	}
 }

--- a/src/SagePayMvc/Internal/TransactionRegistration.cs
+++ b/src/SagePayMvc/Internal/TransactionRegistration.cs
@@ -30,14 +30,19 @@ namespace SagePayMvc.Internal {
 		readonly string customerEMail;
 		readonly string vendorName;
 	    readonly string profile;
+        readonly string accountType;
 		readonly string currency;
 
 	    const string NormalFormMode = "NORMAL";
         const string LowProfileFormMode = "LOW";
 
+        const string AccountTypeEcommerce = "E";
+        const string AccountTypeMailOrder = "M";
+
 		public TransactionRegistration(string vendorTxCode, ShoppingBasket basket, string notificationUrl,
 		                               Address billingAddress, Address deliveryAddress, string customerEmail,
-		                               string vendorName, PaymentFormProfile paymentFormProfile, string currencyCode) {
+		                               string vendorName, PaymentFormProfile paymentFormProfile, string currencyCode, 
+                                        MerchantAccountType accountType) {
 			VendorTxCode = vendorTxCode;
 			NotificationURL = notificationUrl;
 			this.basket = basket;
@@ -53,6 +58,15 @@ namespace SagePayMvc.Internal {
 		            profile = NormalFormMode;
 		            break;
 		    }
+            switch (accountType)
+            {
+                case MerchantAccountType.MailOrder:
+                    this.accountType=AccountTypeMailOrder;
+                    break;
+                default:
+                    this.accountType = AccountTypeEcommerce;
+                    break;
+            }
 			this.currency = currencyCode;
 		}
 
@@ -184,5 +198,9 @@ namespace SagePayMvc.Internal {
 		public string Profile {
 			get { return profile; }
 		}
+        public string AccountType
+        {
+            get { return accountType; }
+        }
 	}
 }

--- a/src/SagePayMvc/Internal/TransactionRegistration.cs
+++ b/src/SagePayMvc/Internal/TransactionRegistration.cs
@@ -29,20 +29,20 @@ namespace SagePayMvc.Internal {
 		readonly Address deliveryAddress;
 		readonly string customerEMail;
 		readonly string vendorName;
-	    readonly string profile;
-        readonly string accountType;
+		readonly string profile;
+		readonly string accountType;
 		readonly string currency;
 
-	    const string NormalFormMode = "NORMAL";
-        const string LowProfileFormMode = "LOW";
+		const string NormalFormMode = "NORMAL";
+		const string LowProfileFormMode = "LOW";
 
-        const string AccountTypeEcommerce = "E";
-        const string AccountTypeMailOrder = "M";
+		const string AccountTypeEcommerce = "E";
+		const string AccountTypeMailOrder = "M";
 
 		public TransactionRegistration(string vendorTxCode, ShoppingBasket basket, string notificationUrl,
-		                               Address billingAddress, Address deliveryAddress, string customerEmail,
-		                               string vendorName, PaymentFormProfile paymentFormProfile, string currencyCode, 
-                                        MerchantAccountType accountType) {
+							Address billingAddress, Address deliveryAddress, string customerEmail,
+							string vendorName, PaymentFormProfile paymentFormProfile, string currencyCode, 
+							MerchantAccountType accountType) {
 			VendorTxCode = vendorTxCode;
 			NotificationURL = notificationUrl;
 			this.basket = basket;
@@ -50,23 +50,23 @@ namespace SagePayMvc.Internal {
 			this.deliveryAddress = deliveryAddress;
 			customerEMail = customerEmail;
 			this.vendorName = vendorName;
-		    switch (paymentFormProfile) {
-		        case PaymentFormProfile.Low:
-		            profile = LowProfileFormMode;
-		            break;
-                default:
-		            profile = NormalFormMode;
-		            break;
-		    }
-            switch (accountType)
-            {
-                case MerchantAccountType.MailOrder:
-                    this.accountType=AccountTypeMailOrder;
-                    break;
-                default:
-                    this.accountType = AccountTypeEcommerce;
-                    break;
-            }
+			switch (paymentFormProfile) {
+				case PaymentFormProfile.Low:
+					profile = LowProfileFormMode;
+					break;
+				default:
+					profile = NormalFormMode;
+					break;
+			}
+			switch (accountType)
+			{
+				case MerchantAccountType.MailOrder:
+					this.accountType=AccountTypeMailOrder;
+					break;
+				default:
+					this.accountType = AccountTypeEcommerce;
+					break;
+			}
 			this.currency = currencyCode;
 		}
 
@@ -198,9 +198,9 @@ namespace SagePayMvc.Internal {
 		public string Profile {
 			get { return profile; }
 		}
-        public string AccountType
-        {
-            get { return accountType; }
-        }
+		public string AccountType
+		{
+			get { return accountType; }
+		}
 	}
 }

--- a/src/SagePayMvc/MerchantAccountType.cs
+++ b/src/SagePayMvc/MerchantAccountType.cs
@@ -1,0 +1,26 @@
+#region License
+// Copyright 2009 The Sixth Form College Farnborough (http://www.farnborough.ac.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at http://github.com/JeremySkinner/SagePayMvc
+#endregion
+
+namespace SagePayMvc
+{
+    public enum MerchantAccountType
+    {
+        Ecommerce,
+        MailOrder
+    }
+}

--- a/src/SagePayMvc/MerchantAccountType.cs
+++ b/src/SagePayMvc/MerchantAccountType.cs
@@ -18,9 +18,9 @@
 
 namespace SagePayMvc
 {
-    public enum MerchantAccountType
-    {
-        Ecommerce,
-        MailOrder
-    }
+	public enum MerchantAccountType
+	{
+		Ecommerce,
+		MailOrder
+	}
 }

--- a/src/SagePayMvc/SagePayMvc.csproj
+++ b/src/SagePayMvc/SagePayMvc.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MerchantAccountType.cs" />
     <Compile Include="ActionResults\ErrorResult.cs" />
     <Compile Include="ActionResults\InvalidSignatureResult.cs" />
     <Compile Include="ActionResults\SagePayResult.cs" />

--- a/src/SagePayMvc/TransactionRegistrar.cs
+++ b/src/SagePayMvc/TransactionRegistrar.cs
@@ -46,8 +46,8 @@ namespace SagePayMvc {
 		}
 
 		public TransactionRegistrationResponse Send(RequestContext context, string vendorTxCode, ShoppingBasket basket,
-		                                            Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode="GBP",
-                                                    MerchantAccountType accountType=MerchantAccountType.Ecommerce) {
+								Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode="GBP",
+								MerchantAccountType accountType=MerchantAccountType.Ecommerce) {
 			string sagePayUrl = configuration.RegistrationUrl;
 			string notificationUrl = urlResolver.BuildNotificationUrl(context);
 
@@ -55,7 +55,7 @@ namespace SagePayMvc {
 				vendorTxCode, basket, notificationUrl,
 				billingAddress, deliveryAddress, customerEmail,
 				configuration.VendorName,
-                paymentFormProfile, currencyCode, accountType);
+				paymentFormProfile, currencyCode, accountType);
 
 			var serializer = new HttpPostSerializer();
 			var postData = serializer.Serialize(registration);

--- a/src/SagePayMvc/TransactionRegistrar.cs
+++ b/src/SagePayMvc/TransactionRegistrar.cs
@@ -46,7 +46,8 @@ namespace SagePayMvc {
 		}
 
 		public TransactionRegistrationResponse Send(RequestContext context, string vendorTxCode, ShoppingBasket basket,
-		                                            Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode="GBP") {
+		                                            Address billingAddress, Address deliveryAddress, string customerEmail, PaymentFormProfile paymentFormProfile = PaymentFormProfile.Normal, string currencyCode="GBP",
+                                                    MerchantAccountType accountType=MerchantAccountType.Ecommerce) {
 			string sagePayUrl = configuration.RegistrationUrl;
 			string notificationUrl = urlResolver.BuildNotificationUrl(context);
 
@@ -54,7 +55,7 @@ namespace SagePayMvc {
 				vendorTxCode, basket, notificationUrl,
 				billingAddress, deliveryAddress, customerEmail,
 				configuration.VendorName,
-                paymentFormProfile, currencyCode);
+                paymentFormProfile, currencyCode, accountType);
 
 			var serializer = new HttpPostSerializer();
 			var postData = serializer.Serialize(registration);


### PR DESCRIPTION
Allows you to specify the Sage Pay account type, enabling the use of this library for Moto payments (Mail Order / Telephone Order).

As discussed here: https://github.com/JeremySkinner/SagePayMvc/issues/5

This is my first github pull request - hope I've included all the info you need.