### PR TITLE
Fix for vendor name as it is required to be lowercase by SagePay

### DIFF
--- a/src/SagePayMvc.Tests/SagePayResponseTester.cs
+++ b/src/SagePayMvc.Tests/SagePayResponseTester.cs
@@ -43,9 +43,16 @@ namespace SagePayMvc.Tests {
 			response.IsSignatureValid(TestHelper.ValidSecurityKey, TestHelper.VendorName).ShouldBeFalse();
 		}
 
-		[Test]
-		public void Returns_true_for_valid_signature() {
-			response.IsSignatureValid(TestHelper.ValidSecurityKey, TestHelper.VendorName).ShouldBeTrue();
-		}
+        [Test]
+        public void Returns_true_for_valid_signature()
+        {
+            response.IsSignatureValid(TestHelper.ValidSecurityKey, TestHelper.VendorName).ShouldBeTrue();
+        }
+
+        [Test]
+        public void Returns_true_for_valid_signature_vendorname_always_lowercase()
+        {
+            response.IsSignatureValid(TestHelper.ValidSecurityKey, TestHelper.VendorNameWithCaps).ShouldBeTrue();
+        }
 	}
 }

--- a/src/SagePayMvc/Internal/TestHelper.cs
+++ b/src/SagePayMvc/Internal/TestHelper.cs
@@ -25,7 +25,8 @@ namespace SagePayMvc.Internal {
 	public static class TestHelper {
 		public const string ValidSecurityKey = "testkey123";
 		public const string ValidSignature = "46EAE2D06815F3406C41776422711985";
-		public const string VendorName = "testvendor";
+        public const string VendorName = "testvendor";
+        public const string VendorNameWithCaps = "TestVendor";
 
 		public static SagePayResponse CreateValidResponse() {
 			return new SagePayResponse {

--- a/src/SagePayMvc/SagePayResponse.cs
+++ b/src/SagePayMvc/SagePayResponse.cs
@@ -73,7 +73,7 @@ namespace SagePayMvc {
 			builder.Append(VendorTxCode);
 			builder.Append(Status.ToString().ToUpper());
 			builder.Append(TxAuthNo);
-			builder.Append(vendorName);
+			builder.Append(vendorName.ToLower());
 			builder.Append(AVSCV2);
 			builder.Append(securityKey);
 			builder.Append(AddressResult);


### PR DESCRIPTION
After signing up with SagePay it was realised that they always treat VendorName as lowercase.

This patch enforces that on the signature verification as this was failing when the VendorName in the web.config was entered with capital letters.
