### PR TITLE
Allow injected config

### DIFF
--- a/src/SagePayMvc/Configuration.cs
+++ b/src/SagePayMvc/Configuration.cs
@@ -94,24 +94,10 @@ namespace SagePayMvc {
 			}
 		}
 
-
 		/// <summary>
-		/// Notification host name. This is required. 
+		/// Notification host name.
 		/// </summary>
-		public string NotificationHostName {
-			get {
-				if (string.IsNullOrEmpty(notificationHostName)) {
-					throw new ArgumentNullException("notificationHostName", "NotificationHostName must be specified in the configuration.");
-				}
-				return notificationHostName;
-			}
-			set {
-				if (string.IsNullOrEmpty(value)) {
-					throw new ArgumentNullException("value", "NotificationHostName must be specified in the configuration.");
-				}
-				notificationHostName = value;
-			}
-		}
+		public string NotificationHostName { get; set; }
 
 		/// <summary>
 		/// Server mode (simulator, test, live)

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -35,7 +35,7 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.FailedController, action = configuration.FailedAction, vendorTxCode});
 
-            string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
 			return url;
 		}
 

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -30,34 +30,40 @@ namespace SagePayMvc {
 		public const string FailedActionName = "Failed";
 		public const string SuccessfulActionName = "Success";
 
+		readonly Configuration configuration;
+
+		/// <summary>
+		/// Creates a new instance of the DefaultUrlResolver using the configuration specified in the web.conf.
+		/// </summary>
+		public DefaultUrlResolver() {
+			configuration = Configuration.Current;
+		}
+
 		public virtual string BuildFailedTransactionUrl(RequestContext context, string vendorTxCode) {
-			var configuration = Configuration.Current;
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.FailedController, action = configuration.FailedAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
 			return url;
 		}
 
 		public virtual string BuildSuccessfulTransactionUrl(RequestContext context, string vendorTxCode) {
-			var configuration = Configuration.Current;
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.SuccessController, action = configuration.SuccessAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
 			return url;
 		}
 
 		public virtual string BuildNotificationUrl(RequestContext context) {
-			var configuration = Configuration.Current;
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.NotificationController, action = configuration.NotificationAction});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
 			return url;
 		}
 
-		public string GetNotificationHostName(Configuration configuration, RequestContext context) {
+		public string GetNotificationHostName(RequestContext context) {
 			return configuration.NotificationHostName ?? context.HttpContext.Request.Url.Host;
 		}
 	}

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -35,7 +35,7 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.FailedController, action = configuration.FailedAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
 			return url;
 		}
 
@@ -44,7 +44,7 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.SuccessController, action = configuration.SuccessAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
 			return url;
 		}
 
@@ -53,8 +53,12 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.NotificationController, action = configuration.NotificationAction});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
 			return url;
+		}
+
+		public string GetNotificationHostName(Configuration configuration, RequestContext context) {
+			return configuration.NotificationHostName ?? context.HttpContext.Request.Url.Host;
 		}
 	}
 }

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -35,8 +35,12 @@ namespace SagePayMvc {
 		/// <summary>
 		/// Creates a new instance of the DefaultUrlResolver using the configuration specified in the web.conf.
 		/// </summary>
-		public DefaultUrlResolver() {
-			configuration = Configuration.Current;
+		public DefaultUrlResolver() : this (Configuration.Current) {
+		}
+
+		public DefaultUrlResolver(Configuration configuration)
+		{
+			this.configuration = configuration;
 		}
 
 		public virtual string BuildFailedTransactionUrl(RequestContext context, string vendorTxCode) {


### PR DESCRIPTION
Allow configuration to be injected

This frees DefaultUrlResolver from the global configuration instance.
This is necessary when multiple configurations are needed in the same
application.
