### PR TITLE
Configure hostnames individually

### DIFF
--- a/src/SagePayMvc/Configuration.cs
+++ b/src/SagePayMvc/Configuration.cs
@@ -94,24 +94,10 @@ namespace SagePayMvc {
 			}
 		}
 
-
 		/// <summary>
-		/// Notification host name. This is required. 
+		/// Notification host name.
 		/// </summary>
-		public string NotificationHostName {
-			get {
-				if (string.IsNullOrEmpty(notificationHostName)) {
-					throw new ArgumentNullException("notificationHostName", "NotificationHostName must be specified in the configuration.");
-				}
-				return notificationHostName;
-			}
-			set {
-				if (string.IsNullOrEmpty(value)) {
-					throw new ArgumentNullException("value", "NotificationHostName must be specified in the configuration.");
-				}
-				notificationHostName = value;
-			}
-		}
+		public string NotificationHostName { get; set; }
 
 		/// <summary>
 		/// Server mode (simulator, test, live)

--- a/src/SagePayMvc/Configuration.cs
+++ b/src/SagePayMvc/Configuration.cs
@@ -129,6 +129,16 @@ namespace SagePayMvc {
 		}
 
 		/// <summary>
+		/// Success host name.
+		/// </summary>
+		public string SuccessHostName { get; set; }
+
+		/// <summary>
+		/// Failed host name.
+		/// </summary>
+		public string FailedHostName { get; set; }
+
+		/// <summary>
 		/// Action name to use when generating the success URL. Default is "Success"
 		/// </summary>
 		public string SuccessAction {
@@ -253,6 +263,8 @@ namespace SagePayMvc {
 			                                      	NotificationHostName = GetValue(x => x.NotificationHostName, section),
 			                                      	NotificationController = GetValue(x => x.NotificationController, section),
 			                                      	notificationAction = GetValue(x => x.NotificationAction, section),
+			                                      	SuccessHostName = GetValue(x => x.SuccessHostName, section),
+			                                      	FailedHostName = GetValue(x => x.FailedHostName, section),
 			                                      	SuccessAction = GetValue(x => x.SuccessAction, section),
 			                                      	FailedAction = GetValue(x => x.FailedAction, section),
 			                                      	SuccessController = GetValue(x => x.SuccessController, section),

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -47,7 +47,8 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.FailedController, action = configuration.FailedAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
+			var hostName = configuration.FailedHostName ?? GetNotificationHostName(context);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, hostName);
 			return url;
 		}
 
@@ -55,7 +56,8 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.SuccessController, action = configuration.SuccessAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
+			var hostName = configuration.SuccessHostName ?? GetNotificationHostName(context);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, hostName);
 			return url;
 		}
 

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -35,7 +35,7 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.FailedController, action = configuration.FailedAction, vendorTxCode});
 
-            string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
 			return url;
 		}
 

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -30,34 +30,40 @@ namespace SagePayMvc {
 		public const string FailedActionName = "Failed";
 		public const string SuccessfulActionName = "Success";
 
+		readonly Configuration configuration;
+
+		/// <summary>
+		/// Creates a new instance of the DefaultUrlResolver using the configuration specified in the web.conf.
+		/// </summary>
+		public DefaultUrlResolver() {
+			configuration = Configuration.Current;
+		}
+
 		public virtual string BuildFailedTransactionUrl(RequestContext context, string vendorTxCode) {
-			var configuration = Configuration.Current;
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.FailedController, action = configuration.FailedAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
 			return url;
 		}
 
 		public virtual string BuildSuccessfulTransactionUrl(RequestContext context, string vendorTxCode) {
-			var configuration = Configuration.Current;
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.SuccessController, action = configuration.SuccessAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
 			return url;
 		}
 
 		public virtual string BuildNotificationUrl(RequestContext context) {
-			var configuration = Configuration.Current;
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.NotificationController, action = configuration.NotificationAction});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(context));
 			return url;
 		}
 
-		public string GetNotificationHostName(Configuration configuration, RequestContext context) {
+		public string GetNotificationHostName(RequestContext context) {
 			return configuration.NotificationHostName ?? context.HttpContext.Request.Url.Host;
 		}
 	}

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -35,7 +35,7 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.FailedController, action = configuration.FailedAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
 			return url;
 		}
 
@@ -44,7 +44,7 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.SuccessController, action = configuration.SuccessAction, vendorTxCode});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
 			return url;
 		}
 
@@ -53,8 +53,12 @@ namespace SagePayMvc {
 			var urlHelper = new UrlHelper(context);
 			var routeValues = new RouteValueDictionary(new {controller = configuration.NotificationController, action = configuration.NotificationAction});
 
-			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, configuration.NotificationHostName);
+			string url = urlHelper.RouteUrl(null, routeValues, configuration.Protocol, GetNotificationHostName(configuration, context));
 			return url;
+		}
+
+		public string GetNotificationHostName(Configuration configuration, RequestContext context) {
+			return configuration.NotificationHostName ?? context.HttpContext.Request.Url.Host;
 		}
 	}
 }

--- a/src/SagePayMvc/DefaultUrlResolver.cs
+++ b/src/SagePayMvc/DefaultUrlResolver.cs
@@ -35,8 +35,12 @@ namespace SagePayMvc {
 		/// <summary>
 		/// Creates a new instance of the DefaultUrlResolver using the configuration specified in the web.conf.
 		/// </summary>
-		public DefaultUrlResolver() {
-			configuration = Configuration.Current;
+		public DefaultUrlResolver() : this (Configuration.Current) {
+		}
+
+		public DefaultUrlResolver(Configuration configuration)
+		{
+			this.configuration = configuration;
 		}
 
 		public virtual string BuildFailedTransactionUrl(RequestContext context, string vendorTxCode) {


### PR DESCRIPTION
Allow hostnames for success and failed to be specified

Previously the hostname specified for notification was used in all
scenarios. Success and Failed URLs do not need to be publicly accessible
so when developing locally these can be set to localhost, or a local
hostname.
